### PR TITLE
Added support for 4bpp RLE bitmap

### DIFF
--- a/main_linux.cpp
+++ b/main_linux.cpp
@@ -34,6 +34,7 @@ typedef struct tagBITMAPFILEHEADER {
   int32_t  bfOffBits;
 } __attribute__((packed)) BITMAPFILEHEADER, *PBITMAPFILEHEADER;
 
+#define BI_RLE4 2
 typedef struct tagBITMAPINFOHEADER {
   int32_t biSize;
   int32_t  biWidth;


### PR DESCRIPTION
Added support for 4bpp RLE bitmap. E.g. GIMP can create this kind of RLE bitmaps.
Note that the compressed image data cannot be mirrored vertically like for uncomressed data.